### PR TITLE
🔗 Fix arrowrbook.com links

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -169,7 +169,7 @@ gtag('config', 'G-SJ58WZL69W', { 'anonymize_ip': true});
 <p>I have a PhD in Statistics, and have been working in R for 15 years.</p>
 <p>During my career, I’ve worked across multiple industries, including pharma, public health, academia, and startups, and on projects encompassing everything from teaching hundreds of new programmers how to work with R, maintaining popular open source packages, to delving into the complexities of deploying R code in production environments where scalability matters.</p>
 <p>I’ve built dashboards and internal tools supporting hundreds of concurrent users, deployed across the NHS, and have developed and led workshops at major R conferences like Posit Conf.</p>
-<p>I am one of the core maintainers of the Apache Arrow R project, acting as package maintainer, and authoring <a href="arrowrbook.com">Scaling Up with R and Arrow</a> - available online and published by CRC Press in 2025.</p>
+<p>I am one of the core maintainers of the Apache Arrow R project, acting as package maintainer, and authoring <a href="https://arrowrbook.com/">Scaling Up with R and Arrow</a> - available online and published by CRC Press in 2025.</p>
 </section>
 <section id="services" class="level2">
 <h2 data-anchor-id="services">Services</h2>

--- a/_site/projects/book/index.html
+++ b/_site/projects/book/index.html
@@ -161,7 +161,7 @@ gtag('config', 'G-SJ58WZL69W', { 'anonymize_ip': true});
 
 
 <p>I’ve been an active contributor to the Apache Arrow R package, where I’ve worked on implementing features, acting as package maintainer, and extending <code>dplyr</code> support to Arrow. This work has influenced how I approach performance, reproducibility, and maintainability - both in open source and in client projects.</p>
-<p>In 2024, I co-authored Scaling Up With R and Arrow, which was <a href="https://www.routledge.com/Scaling-Up-with-R-and-Apache-Arrow-Bigger-Data-Easier-Workflows/Crane-Keane-Richardson/p/book/9781032660288?srsltid=AfmBOooQcBGX3Oc49Yrt1sICgCOiGGf5x1Z7TmzwjXzDZsonZTKKxNQY">published by CRC Press</a> and also <a href="www.arrowrbook.com">available online for free at arrowrbook.com</a>.</p>
+<p>In 2024, I co-authored Scaling Up With R and Arrow, which was <a href="https://www.routledge.com/Scaling-Up-with-R-and-Apache-Arrow-Bigger-Data-Easier-Workflows/Crane-Keane-Richardson/p/book/9781032660288?srsltid=AfmBOooQcBGX3Oc49Yrt1sICgCOiGGf5x1Z7TmzwjXzDZsonZTKKxNQY">published by CRC Press</a> and also <a href="https://arrowrbook.com/">available online for free at arrowrbook.com</a>.</p>
 
 
 

--- a/index.qmd
+++ b/index.qmd
@@ -32,7 +32,7 @@ During my career, I've worked across multiple industries, including pharma, publ
 
 I've built dashboards and internal tools supporting hundreds of concurrent users, deployed across the NHS, and have developed and led workshops at major R conferences like Posit Conf.
 
-I am one of the core maintainers of the Apache Arrow R project, acting as package maintainer, and authoring [Scaling Up with R and Arrow](arrowrbook.com) - available online and published by CRC Press in 2025.
+I am one of the core maintainers of the Apache Arrow R project, acting as package maintainer, and authoring [Scaling Up with R and Arrow](https://arrowrbook.com/) - available online and published by CRC Press in 2025.
 
 ## Services
 

--- a/projects/book/index.qmd
+++ b/projects/book/index.qmd
@@ -6,4 +6,4 @@ image: scaling_up.png
 
 I've been an active contributor to the Apache Arrow R package, where I've worked on implementing features, acting as package maintainer, and extending `dplyr` support to Arrow. This work has influenced how I approach performance, reproducibility, and maintainability - both in open source and in client projects.
 
-In 2024, I co-authored Scaling Up With R and Arrow, which was [published by CRC Press](https://www.routledge.com/Scaling-Up-with-R-and-Apache-Arrow-Bigger-Data-Easier-Workflows/Crane-Keane-Richardson/p/book/9781032660288?srsltid=AfmBOooQcBGX3Oc49Yrt1sICgCOiGGf5x1Z7TmzwjXzDZsonZTKKxNQY) and also [available online for free at arrowrbook.com](www.arrowrbook.com).
+In 2024, I co-authored Scaling Up With R and Arrow, which was [published by CRC Press](https://www.routledge.com/Scaling-Up-with-R-and-Apache-Arrow-Bigger-Data-Easier-Workflows/Crane-Keane-Richardson/p/book/9781032660288?srsltid=AfmBOooQcBGX3Oc49Yrt1sICgCOiGGf5x1Z7TmzwjXzDZsonZTKKxNQY) and also [available online for free at arrowrbook.com](https://arrowrbook.com/).


### PR DESCRIPTION
Links were directing to `https://niccrane.com/projects/book/www.arrowrbook.com` etc.

Looking forward to catching up at Shiny in Production 😄 